### PR TITLE
Fix name of sensorfwd service.

### DIFF
--- a/rpm/unblank-restart-sensors.service
+++ b/rpm/unblank-restart-sensors.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Restart sensord when display wakes up, to hack sensors back to work
+Description=Restart sensorfwd when display wakes up, to hack sensors back to work
 Requires=dbus.socket
 After=mce.service
 

--- a/rpm/unblank-restart-sensors.spec
+++ b/rpm/unblank-restart-sensors.spec
@@ -1,5 +1,5 @@
 Name:       unblank-restart-sensors
-Summary:    Hacky service that restarts sensord after display wakes up
+Summary:    Hacky service that restarts sensorfwd after display wakes up
 Version:    0
 Release:    1
 Group:      System/Applications

--- a/src/unblank-restart-sensors.c
+++ b/src/unblank-restart-sensors.c
@@ -256,7 +256,7 @@ static void xsystemd_restart_unit_free_cb(void *userdata)
 static void xdbus_handle_display_state_signal(DBusMessage *msg)
 {
     const char *name = 0;
-    const char *unit = "sensord.service";
+    const char *unit = "sensorfwd.service";
     const char *mode = "replace";
     
     DBusError   err  = DBUS_ERROR_INIT;


### PR DESCRIPTION
Service was renamed to sensorfwd a long time ago. Tested to work on Find5.
